### PR TITLE
parameterize nut flat width, echo thread specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Great for holding laser-cut sheets together.
 include <lasercut.scad>; 
 
 thickness = 3.1;
-nut_flat_width = 7;
+nut_flat_width = 9.3;
 x = 50;
 y = 100;
 lasercutoutSquare(thickness=thickness, x=x, y=y,

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Great for holding laser-cut sheets together.
 include <lasercut.scad>; 
 
 thickness = 3.1;
+nut_flat_width = 7;
 x = 50;
 y = 100;
 lasercutoutSquare(thickness=thickness, x=x, y=y,
@@ -66,8 +67,8 @@ lasercutoutSquare(thickness=thickness, x=x, y=y,
             [DOWN, x/2, 0]
         ],
     captive_nuts=[
-            [LEFT, 0, y/2],
-            [RIGHT, x, y/2],
+            [LEFT, 0, y/2, nut_flat_width],
+            [RIGHT, x, y/2, nut_flat_width],
             
             ]
 );

--- a/convert-2d.sh
+++ b/convert-2d.sh
@@ -1,9 +1,13 @@
 # Defines where OpenSCAD is installed
 
 openscad_bin() {
-  if [[ "$OSTYPE" == "darwin"* ]]; then
+  if [ -n "$OPENSCAD_BIN" ]
+  then
+    $OPENSCAD_BIN $1
+  elif [[ "$OSTYPE" == "darwin"* ]]
+  then
     /Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD $1
-  else
+  else 
     openscad $1
   fi
 }

--- a/examples.scad
+++ b/examples.scad
@@ -1,6 +1,7 @@
 include <lasercut.scad>; 
 
 thickness = 3.1;
+nut_flat_width = 7;
 x = 100;
 y = 200;
 z =  50;
@@ -15,7 +16,7 @@ module supportLeft()
             [MID, x*.75-thickness/2, height/2]
             ],
         captive_nuts=[
-            [UP, x/2, height] 
+            [UP, x/2, height, nut_flat_width] 
             ],
         twist_holes=[
             [RIGHT, x/2, height/4, height/2]

--- a/lasercut.scad
+++ b/lasercut.scad
@@ -122,7 +122,11 @@ module lasercutout(thickness,  points= [],
         }
         for (t = [0:1:len(captive_nuts)-1]) 
         {
-            captiveNutBoltHole(captive_nuts[t][0], captive_nuts[t][1], captive_nuts[t][2], thickness);
+            if (len(captive_nuts) < 4) {
+                captiveNutBoltHole(captive_nuts[t][0], captive_nuts[t][1], captive_nuts[t][2], thickness*3, thickness);
+            } else {
+                captiveNutBoltHole(captive_nuts[t][0], captive_nuts[t][1], captive_nuts[t][2], captive_nuts[t][3], thickness);
+            }
         }
         for (t = [0:1:len(captive_nut_holes)-1]) 
         {
@@ -248,12 +252,16 @@ module simpleTabHole(angle, x, y, thickness)
      }
 }
 
-module captiveNutBoltHole(angle, x, y, thickness)
+module captiveNutBoltHole(angle, x, y, nut_flat_width, thickness)
 {
     translate([x,y,0]) rotate([0,0,angle-180]) union() 
     {
         translate([-thickness/2,-thickness,-thickness]) cube([thickness, thickness*4, thickness*3]); 
-        translate([-thickness/2-thickness,thickness,-thickness]) cube([thickness*3, thickness, thickness*3]); 
+        echo("screw thread major dia must be < ", thickness);
+        echo("screw thread length must be < ", thickness*5);
+        translate([-nut_flat_width/2,thickness,-thickness]) cube([nut_flat_width, thickness, thickness*3]); 
+        echo("nut thickness must be < ", thickness);
+        echo("nut flats must be < ", nut_flat_width);
     }
 }
 

--- a/lasercut.scad
+++ b/lasercut.scad
@@ -257,11 +257,11 @@ module captiveNutBoltHole(angle, x, y, nut_flat_width, thickness)
     translate([x,y,0]) rotate([0,0,angle-180]) union() 
     {
         translate([-thickness/2,-thickness,-thickness]) cube([thickness, thickness*4, thickness*3]); 
-        echo("screw thread major dia must be < ", thickness);
-        echo("screw thread length must be < ", thickness*5);
+        echo(str("[LC] // screw thread major dia must be < ", thickness));
+        echo(str("[LC] // screw thread length must be < ", thickness*5));
         translate([-nut_flat_width/2,thickness,-thickness]) cube([nut_flat_width, thickness, thickness*3]); 
-        echo("nut thickness must be < ", thickness);
-        echo("nut flats must be < ", nut_flat_width);
+        echo(str("[LC] // nut thickness must be < ", thickness));
+        echo(str("[LC] // nut flats must be < ", nut_flat_width));
     }
 }
 
@@ -491,7 +491,6 @@ module twistConnect(angle, x, y, thickness, max_y, min_y, max_x, min_x)
         translate([x,0,-thickness]) rotate([0,0,angle+90]) union()
         {
             gap = max_y - min_y;
-            echo(gap);
             translate([-gap/2-(thickness*3/2),0,0]) cube([gap, thickness, thickness*3]); 
             translate([+gap/2+(thickness*3/2),0,0]) cube([gap, thickness, thickness*3]); 
         }


### PR DESCRIPTION
Different thread sizes have different proportions of nut flat width
versus thread major diameter, so we shouldn't base nut flat width on
sheet thickness.  This change adds an optional fourth element to the
captive_nuts array, allowing the user to specify the exact nut flat
width.  If the user doesn't specify a nut flat width, then we default
to the legacy behavior of (3 * thickness) to preserve backward
compatibility.

Regardless of whether the user provides a nut flat width, we also
now echo the thread and nut specs to the console at compile time,
to aid the user in selecting hardware.