### PR TITLE
Attempt to fix warnings raised by newer openscad

### DIFF
--- a/lasercut.scad
+++ b/lasercut.scad
@@ -5,7 +5,7 @@ RIGHT = 270;
 MID = 360;
 kerf=0.0;// Hacky global for kerf
 
-generate = $generate == undef ? 0: $generate; 
+generate = 0; 
 
 if (generate == 1)
 {
@@ -85,7 +85,7 @@ module lasercutout(thickness,  points= [],
     { 
         union() 
         {
-            linear_extrude(height = thickness , center = false)  polygon(points=points, path=path);
+            linear_extrude(height = thickness , center = false)  polygon(points=points, paths=path);
             for (t = [0:1:len(simple_tabs)-1]) 
             {
                 simpleTab(simple_tabs[t][0], simple_tabs[t][1], simple_tabs[t][2], thickness);


### PR DESCRIPTION
Specifically, two changes were made:

- There is no special variable called $generate. Define it as 0. '-Dgenerate=1' should still work due to how variables in openscad work.
- Change 'path' to 'paths' in one of the polygon() calls as it seems to be a typo.