### PR TITLE
Added variable to translate lasercutoutSquare to 0 (if externally called)

### DIFF
--- a/lasercut.scad
+++ b/lasercut.scad
@@ -30,9 +30,12 @@ module lasercutoutSquare(thickness, x=0, y=0,
         cutouts_vb = [],
         flat_adjust = [],
         milling_bit = 0.0,
+	internal = false,
 )
 {
     points = [[0,0], [x,0], [x,y], [0,y], [0,0]];
+lcovar1= internal ? 0 : thickness;
+translate([lcovar1, lcovar1, 0])
 lasercutout(thickness=thickness,  
         points = points, 
         simple_tabs = simple_tabs, 
@@ -707,7 +710,8 @@ module lasercutoutBoxAdjustedFJ(thickness, x=0, y=0, z=0, sides=6, fj=[], st=[],
                                 circles_add = circles_add_a[0], circles_remove = circles_remove_a[0],
                                 slits = slits_a[0],
                                 cutouts = cutouts_a[0],
-                                milling_bit = milling_bit);
+                                milling_bit = milling_bit,
+				internal = true);
 
     translate([0,0,z+thickness]) lasercutoutSquare(thickness=thickness,x=x, y=y, simple_tabs = st[1], finger_joints = fj[1],
                                 simple_tab_holes=simple_tab_holes_a[1], captive_nuts=captive_nuts_a[1],
@@ -718,7 +722,8 @@ module lasercutoutBoxAdjustedFJ(thickness, x=0, y=0, z=0, sides=6, fj=[], st=[],
                                 circles_add = circles_add_a[1], circles_remove = circles_remove_a[1],
                                 slits = slits_a[1],
                                 cutouts = cutouts_a[1],
-                                milling_bit = milling_bit);
+                                milling_bit = milling_bit,
+				internal = true);
 
     translate([0,0,thickness]) rotate([90,0,0]) lasercutoutSquare(thickness=thickness,x=x, y=z, finger_joints = fj[2],
                                 simple_tab_holes=simple_tab_holes_a[2], captive_nuts=captive_nuts_a[2],
@@ -729,7 +734,8 @@ module lasercutoutBoxAdjustedFJ(thickness, x=0, y=0, z=0, sides=6, fj=[], st=[],
                                 circles_add = circles_add_a[2], circles_remove = circles_remove_a[2],
                                 slits = slits_a[2],
                                 cutouts = cutouts_a[2],
-                                milling_bit = milling_bit);
+                                milling_bit = milling_bit,
+				internal = true);
 
     translate([0,y+thickness,thickness]) rotate([90,0,0]) lasercutoutSquare(thickness=thickness,x=x, y=z, simple_tabs = st[2], 
                                 finger_joints = fj[3],
@@ -741,8 +747,8 @@ module lasercutoutBoxAdjustedFJ(thickness, x=0, y=0, z=0, sides=6, fj=[], st=[],
                                 circles_add = circles_add_a[3], circles_remove = circles_remove_a[3],
                                 slits = slits_a[3],
                                 cutouts = cutouts_a[3],
-                                milling_bit = milling_bit
-                                );
+                                milling_bit = milling_bit,
+                                internal = true);
     
     if (sides>4)
     {
@@ -755,7 +761,8 @@ module lasercutoutBoxAdjustedFJ(thickness, x=0, y=0, z=0, sides=6, fj=[], st=[],
                                 circles_add = circles_add_a[4], circles_remove = circles_remove_a[4],
                                 slits = slits_a[4],
                                 cutouts = cutouts_a[4],
-                                milling_bit = milling_bit);
+                                milling_bit = milling_bit,
+				internal = true);
         }
     
     if (sides>5)
@@ -770,7 +777,8 @@ module lasercutoutBoxAdjustedFJ(thickness, x=0, y=0, z=0, sides=6, fj=[], st=[],
                                 circles_add = circles_add_a[5], circles_remove = circles_remove_a[5],
                                 slits = slits_a[5],
                                 cutouts = cutouts_a[5],
-                                milling_bit = milling_bit);
+                                milling_bit = milling_bit,
+				internal = true);
     }
 }
 
@@ -948,8 +956,8 @@ module lasercutoutVinylBox(thickness, x=0, y=0, z=0, sides=6, overlapdistance=-1
                 circles_add = circles_add_a[2], circles_remove = circles_remove_a[2],
                 slits = slits_a[2],
                 cutouts = cutouts_a[2],
-                milling_bit = milling_bit
-                );        
+                milling_bit = milling_bit,
+                internal = true);        
     }
     if (sides>3)
     {
@@ -965,8 +973,8 @@ module lasercutoutVinylBox(thickness, x=0, y=0, z=0, sides=6, overlapdistance=-1
                 circles_add = circles_add_a[3], circles_remove = circles_remove_a[3],
                 slits = slits_a[3],
                 cutouts = cutouts_a[3],
-                milling_bit = milling_bit
-                );        
+                milling_bit = milling_bit,
+                internal = true);        
     }
     if (sides>4)
     {


### PR DESCRIPTION
Added variable to translate lasercutoutSquare a single thickness on the X and Y if being called as a module from a non library-internal source. This lines up a single tabbed object on 0.