### PR TITLE
convert-2d.py: fix SVG generation

### DIFF
--- a/convert-2d.py
+++ b/convert-2d.py
@@ -278,6 +278,7 @@ if generate_non_scad_file:
     output = subprocess.run(
         f'"{openscad_path}" "{processed_scad_path}" -o "{output_abs_path}"',
         capture_output=True,
+        shell=True
     )
 
     if output.returncode != 0:


### PR DESCRIPTION
Seems using the shell is required to not have the whole command line being taken as the executable path.